### PR TITLE
Fix product articles: syntax, typos, and images

### DIFF
--- a/products/operating-systems/custom-ipxe.md
+++ b/products/operating-systems/custom-ipxe.md
@@ -7,79 +7,65 @@
 }
 </meta>-->
 
-### **Introduction**
+### Introduction
 
 Packet supports passing custom iPXE scripts during provisioning, which allows you to install a custom operating system manually, or via automated kickstart.
 
 Since we don’t test any manually installed operating system, it goes without saying that you’ll need to be familiar with our [S.O.S. and rescue mode](https://support.packet.com/kb/articles/rescue-mode) services in case you need to troubleshoot your server.
 
+### Step-by-Step Usage
 
-### **Step-by-Step Usage**
+Select the "Custom iPXE" operating system from the portal, or the custom_ipxe slug if using the API.
 
-Select the "Custom iPXE" operating system from the portal, or the custom\_ipxe slug if using the API.
+![deploy iPXE 1](/images/custom-ipxe/Deploy-iPXE-1.png)
 
-![](https://deskpro-cloud.s3.amazonaws.com/files/26944/43/42167SPMSRHSSMRGSQTS0-1539831490489.png)
+If you have your iPXE script hosted at a publicly accessible http(s) location, put the URL to your script in the text field, or use the ipxe_script_url API parameter. When we serve up iPXE during the boot process we will chain-load your iPXE script URL.  
 
-  
+![deploy iPXE 2](/images/custom-ipxe/Deploy-iPXE-2.png)
 
-If you have your iPXE script hosted at a publicly accessible http(s) location, put the URL to your script in the text field, or use the ipxe\_script\_url API parameter. When we serve up iPXE during the boot process we will chain-load your iPXE script URL.  
-  
-Should the device fail during ipxe boot, with your device set to persistently boot from iPXE you can edit your iPXE URL  reboot the device to try again. 
+Should the device fail during ipxe boot, with your device set to persistently boot from iPXE you can edit your iPXE URL  reboot the device to try again.
 
-![](https://deskpro-cloud.s3.amazonaws.com/files/26944/43/42165ZYZWASDKHDXTBPW0-1539831489605.png)
+![deploy options 2](/images/custom-ipxe/Deploy-Options-2.png)
 
-  
+Alternatively, you can pass the contents of your iPXE script directly via user-data with the #!ipxe hashbang. User data is also a feature in which you can edit should your provisioning with iPXE fail.
 
-Alternatively, you can pass the contents of your iPXE script directly via user-data with the #!ipxe hashbang. User data is also a feature in which you can edit should your provisioning with iPXE fail. 
+![deploy options 1](/images/custom-ipxe/Deploy-Options-1.png)
 
-![](https://deskpro-cloud.s3.amazonaws.com/files/26944/43/42168ZWTSGCAAKKBMDNB0-1539831490786.png)
-
-  
-
-After serving up iPXE via DHCP, the device will be marked as active in our API and portal. Since the server is sitting on the Bootloader Options and it has no ssh access, we will have to use our [Console Access](https://support.packet.com/kb/articles/sos-serial-over-ssh). 
-
-  
+After serving up iPXE via DHCP, the device will be marked as active in our API and portal. Since the server is sitting on the Bootloader Options and it has no ssh access, we will have to use our [Console Access](/product/servers/how-to-deploy/sos-serial-over-ssh.md).
 
 `ssh device-id@sos.facility-code.packet.net`
 
-  
+### Netboot.xyz
 
-**Netboot.xyz**
 If you're using netboot.xyz to manually install your operating system, once you connect to our S.O.S. service, you will see the following:
 
-![](https://deskpro-cloud.s3.amazonaws.com/files/26944/43/42169XDHKRAABGWGXWAN0-1539831491179.png)
+![netboot.xyz](/images/custom-ipxe/Netboot.xyz.png)
 
-
-For more information about each of the OSes, you can go to [netboot.xyz](https://netboot.xyz/) 
+For more information about each of the OSes, you can go to [netboot.xyz](https://netboot.xyz/)
 
 If the operating System is not listed there, you can install via ISO by selecting the iPXE shell option and enter the following;
 
 ```
-kernel https://boot.netboot.xyz/memdisk iso raw 
-initrd http://url/to/iso 
+kernel https://boot.netboot.xyz/memdisk iso raw
+initrd http://url/to/iso
 boot
 ```
 
 If it fails during initramfs trying to load the CD device, update the install media to look for install media via the memdisk. More information can be found about this issue [here](https://www.reversengineered.com/2016/01/07/booting-linux-isos-with-memdisk-and-ipxe/).
 
-
-
-### **Persisting PXE**
-
-  
+### Persisting PXE
 
 When provisioning the Custom iPXE operating system kicks off, we set the next boot option to PXE on first boot.  By default, this PXE process only happens once on the first boot. To set your device to continuously boot to iPXE first, you can edit it under 'server actions' through the customer portal.
 
-![](https://deskpro-cloud.s3.amazonaws.com/files/26944/43/42166GYYJSTWJSYSTYNJ0-1539831490124.png)
+![](/images/custom-ipxe/Persisting-PXE.png)
 
-If true, PXE will persist as the first boot option past initial provisioning reboots.   This is great for testing your iPXE provisioning script and lays the foundation for future, "always-pxe-based OS's" on Packet.
+If true, PXE will persist as the first boot option past initial provisioning reboots. This is great for testing your iPXE provisioning script and lays the foundation for future, "always-pxe-based OS's" on Packet.
 
-
-### **Custom iPXE Usage Notes**
+### Custom iPXE Usage Notes
 
 *   If you would like to interact with your device via S.O.S. to perform a manual install and are not using netboot.xyz, our x86 servers require console=ttyS1,115200n8, and our aarch64 servers require console=ttyAMA0,115200.
-*   DHCP is available during a Custom iPXE device's entire life, so you can get network configured via DHCP and then setup networking statically in the OS by discovering the IP address information from our ec2-style metadata service: [https://metadata.packet.net/metadata](https://metadata.packet.net/metadata) from the host.
+*   DHCP is available during a Custom iPXE device's entire life, so you can get network configured via DHCP and then setup networking statically in the OS by discovering the IP address information from our ec2-style metadata service. From the host server, run `curl https://metadata.packet.net/metadata`.
 *   We load up our own iPXE build which chain-loads a Packet-managed /auto.ipxe script that will serve up either the chain-loaded iPXE script URL that you specify or the #!ipxe script if you've passed in your script directly via userdata.
 *   We set the variable set ipxe\_cloud\_config packet prior to any chain-loading or running your iPXE script. You can use this to perform Packet-specific iPXE commands if you want to maintain a unified iPXE script.
 
-**_Please Note_**_: If you chain-load your own iPXE build/version, you'll likely lose the ipxe\_cloud\_config variable._
+**_Please Note_**: If you chain-load your own iPXE build/version, you'll likely lose the ipxe_cloud_config variable._

--- a/products/servers/configurations/computeclasses.md
+++ b/products/servers/configurations/computeclasses.md
@@ -7,28 +7,21 @@
 }
 </meta>-->
 
-  
-
 As our server lineup grows, it has become harder to scale the very simplistic naming convention we started with (e.g. Type 1, Type 2, etc).
 
 While we deeply value simplicity, we place a premium on clarity.  As such, to help users identify and leverage the right configurations more easily, we are introducing Classes in February 2018.
-
-
 
 #### What are Classes?
 
 Classes are groupings derived from common use cases.  If you're an AWS user, this will seem pretty familiar.  Packet organizes servers into the following classes:
 
-*   **Tiny (t)** - Smaller instances, aimed at dev/test, controller nodes, etc.
-*   **Compute (c)** - Compute focused, with a modest RAM footprint.
-*   **GPU (g)** - GPU focused with  generous RAM 
-*   **Memory (m)** - Memory heavy, with a generous RAM to core ratio.
-*   **Network (n)** - Focused on network use cases, such as ingress / load balancing.
-*   **Storage (s)** - Scale out boxes for storage scenarios.
-*   **Accelerator (x) **\- FPGA and other specialty accelerator focused servers.
-
-  
-
+*   __Tiny (t)__ - Smaller instances, aimed at dev/test, controller nodes, etc.
+*   __Compute (c)__ - Compute focused, with a modest RAM footprint.
+*   __GPU (g)__ - GPU focused with  generous RAM
+*   __Memory (m)__ - Memory heavy, with a generous RAM to core ratio.
+*   __Network (n)__ - Focused on network use cases, such as ingress / load balancing.
+*   __Storage (s)__ - Scale out boxes for storage scenarios.
+*   __Accelerator (x)__ - FPGA and other specialty accelerator focused servers.
 
 #### Server Naming Convention
 
@@ -36,69 +29,49 @@ All instances have a name that follows a formula to help you understand its purp
 
 By piecing these features together, we arrive at a name, such as c1.small.x86 - indicating a small compute class server, in its 1st generation with an x86 processor.  Since most of our systems are x86 currently, we'll provide nicknames so you can use "c1.small" for shorthand.
 
-
 #### What are Generations?
 
 Generations are updated when we significantly upgrade or change the components.  
 
 This is usually around a major processor refresh, but often also relates to the underlying hardware configuration / chassis.  As such, a "1st" generation system is not necessarily outdated, it is simply our first iteration of a particular configuration.
 
+#### What About Previous Server Names and API Calls?  
 
+Packet previously labeled servers using Types, such as "Type 1" which was represented in the API as "baremetal_1".  
 
-#### What About Previous Server Names and API Calls?
+_These will still work_--we have simply made an alias in which baremetal_1 translates to its new name:  "c1.small.x86".  
 
-  
-
-Packet previously labeled servers using Types, such as "Type 1" which was represented in the API as "baremetal\_1".  
-
-_These will still work_ - we have simply made an alias in which baremetal\_1 translates to its new name:  "c1.small.x86".  
-
-However, new instances (such as our AMD configuration introduced in February, 2018) can only be accessed by the new class-based name or nickname.  In this case: "c2.medium.x86" or just "c2.medium" for short. 
-
+However, new instances (such as our AMD configuration introduced in February, 2018) can only be accessed by the new class-based name or nickname.  In this case: "c2.medium.x86" or just "c2.medium" for short.
 
 #### List of All Servers / Names
 
-The following represents our current lineup of servers, publicly available in February 2018.  Previous names are mentioned in parentheses.
-
-  
+The following represents our current lineup of servers, publicly available in February 2018.  Previous names are mentioned in parentheses.  
 
 ---
+__Tiny (t)__
+* t1.small
 
-Tiny (t)
---------
+__Compute (c)__
+* c1.small
+* c2.medium
+* c1.large.arm
+* c2.large.arm
+* c1.xlarge
+* c1.large.arm.xda
 
-*   t1.small 
+__GPU (g)__
+* g2.large
 
-Compute (c)
------------
+__Memory (m)__
+* m1.xlarge
+* m2.xlarge
 
-*   c1.small 
-*   c2.medium 
-*   c1.large.arm 
-*   c1.xlarge 
-*   c1.large.arm.xda
+__Network (n)__
+* There are no 'n' class servers yet.
 
-GPU (g) 
+__Storage (s)__
+* s1.large
 
-*   g2.large
-
-Memory (m)
-----------
-
-*   m1.xlarge 
-*   m2.xlarge 
-
-Network (n)
------------
-
-*   There are no 'n' class servers yet.
-
-Storage (s)
------------
-
-*   s1.large 
-
-Accelerator (x)
----------------
-
-*   x1.small
+__Accelerator (x)__
+* x1.small
+* x2.xlarge

--- a/products/servers/configurations/cpr.md
+++ b/products/servers/configurations/cpr.md
@@ -1,7 +1,7 @@
 <!--<meta>
 {
     "title":"Custom Partitioning and RAID",
-    "description":"Setting up CPR (Custom Partitioning & RAID)",
+    "description":"Setting up CPR (Custom Partitioning & RAID).",
     "date": "09/20/2019",
     "tag":["CPR", "Custom RAID", "RAID", "Partition"]
 }
@@ -14,19 +14,19 @@ _Please note: this feature is not available for on-demand instances.  A reserved
 
 ### Getting Started
 
-First things first, you should be familiar with the API calls available for device provisioning ([view them here](https://www.packet.com/developers/api/devices/)).   You'll need them!
+First things first, you should be familiar with the [API calls available for device provisioning](https://www.packet.com/developers/api/devices/), you'll need them!
 
 You should also be aware of our standard disk configurations for each server type.  With a few hardware-specific exceptions, generally speaking, this looks like:
 
-*   **t1.small.x86**:   1 × 80 GB, no RAID
-*   **c1.small.x86**:   2 × 120 GB SSD in RAID 1
-*   **x1.small.x86**:   240 GB of SSD (1 × 240 GB)
-*   **m1.xlarge.86:**   2.8 TB of SSD (6 × 480GB SSD)
-*   **m2.xlarge.x86** (Intel Scalable): 2 × 120 GB in RAID 1 & 3.8 TB of NVMe Flash
-*   **c1.larger.arm**: 1 × 340 GB SSD, no RAID
-*   **c1.xlarge.x86**:  2 × 120 GB SSD in RAID 1
-*   **c2.medium.x86 (EPYC)**: 960 GB of SSD (2 x 480 GB)
-*   **s1.large.x86**:  2 x 480 GB SSD in RAID 1, with 120 GB SSD as cache in front of 12 X 2 TB HDD.
+*   __t1.small.x86__:   1 × 80 GB, no RAID
+*   __c1.small.x86__:   2 × 120 GB SSD in RAID 1
+*   __x1.small.x86__:   240 GB of SSD (1 × 240 GB)
+*   __m1.xlarge.86:__   2.8 TB of SSD (6 × 480GB SSD)
+*   __m2.xlarge.x86__ (Intel Scalable): 2 × 120 GB in RAID 1 & 3.8 TB of NVMe Flash
+*   __c1.larger.arm__: 1 × 340 GB SSD, no RAID
+*   __c1.xlarge.x86__:  2 × 120 GB SSD in RAID 1
+*   __c2.medium.x86 (EPYC)__: 960 GB of SSD (2 x 480 GB)
+*   __s1.large.x86__:  2 x 480 GB SSD in RAID 1, with 120 GB SSD as cache in front of 12 X 2 TB HDD.
 
 ### Using CPR During Provisioning
 
@@ -41,10 +41,10 @@ Note: 'storage' and 'string' are where you would specifically state your configu
 
 Using a simple t1.small.x86 to start, the following example shows you how to:
 
-*   State which disks you want to format.
-*   How you want these disks formatted.
-*   What filesystem should be created.  
-*   Where to mount the partition once created.
+* State which disks you want to format.
+* How you want these disks formatted.
+* What filesystem should be created.
+* Where to mount the partition once created.
 
 ```
 {

--- a/products/servers/deployment-options/deployment-batch.md
+++ b/products/servers/deployment-options/deployment-batch.md
@@ -12,41 +12,30 @@ Batch deployment is a feature that enables you to deploy multiple servers at onc
 With batch deployments you can choose the server types & any facility that suits your particular deployment needs.  It is also possible to create several batches at once, such as in the following example, which shows how to deploy three c1.small.
 
 ```
-{ 
-
-    'batches": \[
-
+{
+    'batches": [
         {
-
             "hostname": "test.server.com".
-
             "description": "This is my test server",
-
             "plan": "c1.small",
-
-            "operating\_system": "coreos\_stable",
-
+            "operating_system": "coreos_stable",
             "facility": "any",
-
-            "billing\_cycle": "hourly",
-
-            "tags": \["test1", "test2"\],
-
+            "billing_cycle": "hourly",
+            "tags": ["test1", "test2"],
             "quantity = 10"
-
-            \]
-
+            ]
 }
 ```
-Passing `facility any` the API selects which facility/facilities to deploy based on the most available capacity for the requested type. The above would deploy 10 servers. EWR1 could receive 7 and SJC1 could receive 3. 
 
-In addition to prioritized location selection, it is possible to indicate how many facilities to spread across. For this purpose, the parameter to use is: `facility_diversity_level = N` 
+Passing `facility any` the API selects which facility/facilities to deploy based on the most available capacity for the requested type. The above would deploy 10 servers. EWR1 could receive 7 and SJC1 could receive 3.
 
-Example: 
+In addition to prioritized location selection, it is possible to indicate how many facilities to spread across. For this purpose, the parameter to use is: `facility_diversity_level = N`
+
+Example:
 
 ```
-"facility: \['sjc1', 'ewr1', 'any'\]"
-"facility\_diversity\_level = 1"
+"facility: ['sjc1', 'ewr1', 'any']"
+"facility_diversity_level = 1"
 "quantity = 10”
 
 SJC1: 7 available
@@ -54,11 +43,11 @@ EWR1: 24 available
 DFW1: 50 available
 => 10 deployed to EWR1
 ```
-  
 
-Another example, with larger batch request: 
+Another example, with larger batch request:
 
-```"facility\_diversity\_level = 2" with "quantity = 25"
+```
+"facility_diversity_level = 2" with "quantity = 25"
 
 SJC1: 7 available
 EWR1: 24 available
@@ -68,33 +57,31 @@ DFW1: 50 available
 
 If this parameter is not specified, we don't enforce any limit and device provisioning could be spread across 1 or 2 or all facilities.
 
-### **Naming Scheme: Series vs Custom**
+### Naming Scheme: Series vs Custom
 
 In terms of hostnames, you can handle this in two different ways:
 
-*   **Series**:  You can create a parseable hostname, `"hostname":"s{{index}}.blah.com"`  where`{{index}}`  will be replaced during creation in a logical order (e.g. 1, 2, 3).
-*   **Hostname**: You can pass the API an array of hostnames to use.
+*   __Series__:  You can create a parseable hostname, `"hostname":"s{{index}}.blah.com"`  where`{{index}}`  will be replaced during creation in a logical order (e.g. 1, 2, 3).
+*   __Hostname__: You can pass the API an array of hostnames to use.
 
 
-### **Checking the Status of Batch Deployments**
+### Checking the Status of Batch Deployments
 
-There are four states you can see: 
+There are four states you can see:
 
 *   queued
-*   in\_progress
+*   in_progress
 *   completed
-*   failed 
+*   failed
 
-A batch deployment starts as ‘queued’ once it is requested.  At this stage our worker will begin to work on validations & creations. 
+A batch deployment starts as ‘queued’ once it is requested.  At this stage our worker will begin to work on validations & creations.
 
-Once it passes validation, it will move to ‘in\_progress’.  
+Once it passes validation, it will move to ‘in_progress’.  
 
-If there are devices to fulfill the batch request(s), it will move to ‘completed’. 
+If there are devices to fulfill the batch request(s), it will move to ‘completed’.
 
 If for some reason we are unable to create all the devices, the batch request will be marked as ‘failed’ and you will be able to see why in `‘error_messages’`  returned by the API.
 
-###   
-
-### **Using Batch Deployment with Spot Market**
+### Using Batch Deployment with Spot Market
 
 We actually created batch deployments while developing our [Spot Market](https://support.packet.com/kb/articles/spot-market) feature, as we need to validate the prices / availability in batches before each spot instance is deployed.

--- a/products/servers/deployment-options/reserved-hardware.md
+++ b/products/servers/deployment-options/reserved-hardware.md
@@ -66,6 +66,7 @@ To create a device using a specific hardware reservation, there is a new JSON pa
 `POST https://api.packet.net/projects/<id>/devices -d '{"hardware_reservation_id":"uuid"}'`
 
 An example of provisioning reserved hardware in EWR:
+
 ```
 curl -X POST \
 -H "Content-Type: application/json" \

--- a/products/servers/deployment-options/spot-market.md
+++ b/products/servers/deployment-options/spot-market.md
@@ -21,9 +21,7 @@ In short: the spot market is a marketplace with constantly changing inventory.  
 
 For example, you can provision five instances and pass the **_spot_price_max_**  parameter with the maximum price you want to pay per hour per instance.  If your price is equal to or greater than the current spot price for the given facility / plan, then the instances will be created for you.
 
-{% hint style="warning" %}
 These instances are volatile, which means that they can be revoked by Packet at any time if another user bids with a higher price.
-{% endhint %}
 
 ### Spot Instance Creation
 
@@ -35,6 +33,7 @@ This works much like creating a traditional instance.  The only difference in th
 * __spot_price_max:__ the maximum price you are willing to pay for the instance, per hour. This should be greater or equal than the current spot price for the given facility and plan.
 
 Here is an example in JSON format of making a spot instance request:
+
 ```
 {
     "hostname": "spot-instance",
@@ -47,6 +46,7 @@ Here is an example in JSON format of making a spot instance request:
     "spot_price_max":0.3
 }
 ```
+
 **Please Note:** Date/Time is ISO8601.
 
 ### Persistent Spot Market
@@ -54,7 +54,8 @@ Here is an example in JSON format of making a spot instance request:
 Persistent Spot Market  is the ability to create spot instances whenever the market price drops below a certain threshold without having to query the API constantly and issue device creation requests.
 
 ### API Examples of Persistent Spot Market
-  **Create:**
+
+**Create:**
 ```
 POST /projects/acc88c1a-1ec3-4a9d-86bc-8febab4ef45b/spot-market-requests with the payload:
       """
@@ -75,11 +76,15 @@ POST /projects/acc88c1a-1ec3-4a9d-86bc-8febab4ef45b/spot-market-requests with th
       """
 This should prompt a 200 response.
 ```
+
 **Delete:**
+
 ```
 DELETE /spot-market-requests/f01b4bb1-f93f-46d2-ab44-e1709878208b?force_termination=true
 ```
+
 **Additional parameters:**
+
 ```
 devices_min = 5
 devices_max = 10
@@ -88,17 +93,21 @@ max_bid_price
 device-specific parameters:planoperating systemuserdatapublic_ipv4_subnet_sizessh_keysoperating_systemhostnames
 end_at
 ```
+
 ### Spot Market Termination
 
 Ascertaining when an instance will be terminated is not visible through our customer portal.  Instead, you will need to curl against our API to get this information.
 
-* **From the API:**
+* __From the API:__
+
 ```
 curl -X GET --header 'Accept: application/json' --header 'X-Auth-Token: token' 'https://api.packet.net/projects/projectUUID/devices' | jq '.termination_time'
 ```
+
 The above will output the time when an instance will be revoked/terminated.  If the response is `null` , it indicates that no termination time has been set.
 
-* **From within an instance:**
+* __From within an instance:__
+
 ```
 curl -s https://metadata.packet.net/metadata | jq '.termination_date'
 ```

--- a/products/servers/how-to-deploy/rescue-mode.md
+++ b/products/servers/how-to-deploy/rescue-mode.md
@@ -11,7 +11,6 @@ There are times when a server becomes unreachable over SSH due to broken network
 
 If you have your server's root password and your SSH key, you should use our [S.O.S (Serial over SSH) service](https://help.packet.com/technical/networking/sos-serial-over-ssh).
 
-
 ### Using Rescue Mode
 
 When you can’t log into your server at all (e.g. you don't have the root password or the server won’t boot up) you can use our Rescue Mode, which loads a vanilla Alpine Linux image into your server's RAM.
@@ -21,6 +20,7 @@ To enter Rescue Mode, you need to access the server’s detail page via the Pack
 Clicking on `Rescue` reboots the server and loads the Rescue OS. Once Rescue OS is loaded, the server boots into it.
 
 Now you can SSH in as root using authorized SSH Keys:
+
 ```
 ssh -i /path/to/private.key root@SERVER_IP_HERE
 ===============================================
@@ -29,6 +29,7 @@ Use "apk" package manager for additional utilities.
 See docs at http://wiki.alpinelinux.org
 localhost:~#
 ```
+
 ### Mount Original Root Partition
 
 Next, you'll need to mount the original OS's root partition.
@@ -44,12 +45,14 @@ For c1.small, m1.xlarge, and c1.xlarge servers, the root partition is located in
 **note:** replace xxx with the actual number of the md device.
 
 Once you have access to the root partition you can repair it.
+
 ```
 localhost:/mnt#ls
 bin    dev    home    lib64    media opt        root
 sbin   sys    usrboot etc      lib   lost+found mnt
 proc   run    srv     tmp      var
 ```
+
 In order to get back to the Original OS, we can simply reboot the server.
 
 ### Two Common Use Cases / Situations
@@ -60,6 +63,7 @@ In cases when you can normally SSH into your server and can’t use SOS because 
 * Option 1:
 
   After mounting the root filesystem to /mnt, we can use chroot to load the mounted filesystem and directly use the sudo passwd command to modify the existing root password.
+
   ```
   chroot /mnt /bin/bash
 

--- a/products/servers/how-to-deploy/sos-serial-over-ssh.md
+++ b/products/servers/how-to-deploy/sos-serial-over-ssh.md
@@ -9,35 +9,29 @@
 
 There are times when a server becomes unreachable over SSH due to broken networking, a bad install, misconfiguration, a kernel upgrade, bad firewall rules, etc.
 
-If you have your server's root password and your SSH key, please follow the instructions below.  If you do not have these assets, you should _[_leverage our Rescue Mode_](https://support.packet.com/kb/articles/rescue-mode).
-
-  
+If you have your server's root password and your SSH key, please follow the instructions below.  If you do not have these assets, you should [_leverage our Rescue Mode_](/product/servers/how-to-deploy/rescue-mode.md).
 
 #### Using SOS for Out of Band Access
 
-Packet offers an out of band access method that we call "SOS" - which stands for **S**erial **O**ver **S**SH.   In order to use SOS you will need your server's root password and valid SSH key.
+Packet offers an out of band access method that we call "SOS" - which stands for Serial Over SSH. In order to use SOS you will need your server's root password and valid SSH key.
 
+#### Using SOS
 
-#### Using SSH
-
-`ssh {server-uuid}@sos.{facility-code}.packet.net`
-
-  
+`ssh {server-uuid}@sos.{facility-code}.packet.net`  
 
 *   You can find the **{server-uuid}** on the server details section in our user portal.
-*   For a full list of **{facility-code}** options (e.g. ewr1, sjc1, ams1, etc) [click here](https://support.packet.com/kb/articles/data-centers).
-*   If you have multiple keys locally, use the`-i` flag to specifically choose the correct key. 
+*   For a full list of **{facility-code}** options (e.g. ewr1, sjc1, ams1, etc) see our [Data Centers](/platform/common-questions/data-centers.md) article.
+*   If you have multiple keys locally, use the`-i` flag to specifically choose the correct key.
 
-````
-ssh 4df512fd-253f-428e-867f-9107a6c925fb@sos.ewr1.packet.net -i /path/to/correct/key
-````
+  ````
+  ssh 4df512fd-253f-428e-867f-9107a6c925fb@sos.ewr1.packet.net -i /path/to/correct/key
+  ````
 
+### Run it
 
-### #2 - Run it
+Open up a terminal window and enter the command.
 
-Open up a terminal window and enter the command. 
-
-We don’t keep a persistent connection to the serial console on every server, so when you connect there won’t be any previous output.  You will likely need to press enter/return before it asks for username and password. 
+We don’t keep a persistent connection to the serial console on every server, so when you connect there won’t be any previous output.  You will likely need to press enter/return before it asks for username and password.
 
 If you disconnected previously without logging out, you may already be logged in.
 
@@ -47,11 +41,7 @@ A few things to note:
 *   If you try to connect to the console while the server is still provisioning, it will place you in a read-only mode until up to 30 seconds after the server has finished provisioning.
 *   If you don't see any output after connecting to SOS (common when using a custom image, operating system, or iPXE) please ensure that you have your console settings setup correctly. For x86 servers, use `ttyS1,115200n8`. For aarch64 servers, use `ttyAMA0,115200`.
 
-  
-
----
-
-### #3 - Disconnect
+### Disconnect
 
 In order to disconnect from the server you need to enter `~.` (tilde followed by period). SSH only accepts the escape character after a new line, so you may need to press enter/return first, followed by `~.` .
 

--- a/products/servers/how-to-deploy/ssh-keys.md
+++ b/products/servers/how-to-deploy/ssh-keys.md
@@ -34,9 +34,7 @@ Your public SSH key is commonly located here `/home/yourname/.ssh/<key-name>.pub
 
 `cat ~/.ssh/id_rsa.pub`
 
-
 ### The PuTTY Way (Windows)
-
 
 First, Download [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html). The two binaries you will need are:
 
@@ -60,6 +58,7 @@ Click the Save private key button, name it whatever you like and choose a secure
 Repeat the same thing after clicking on Save public key. This time, make sure to give it an extension like ".txt", so you can open it later in a regular text editor.
 
 **Note!** If you open the public key text file you just saved, you will probably see that it contains something that looks like the following:
+
 ```
 ---- BEGIN SSH2 PUBLIC KEY ----
 
@@ -69,15 +68,14 @@ Comment: "rsa-key-xxxxxx"
 
 ---- END SSH2 PUBLIC KEY ----
 ```
+
 Why Putty saves it in this format is unclear, but it is not an accepted form of adding the public key.
 
 So, for that reason, you might want to copy whatever the Putty Generator shows on the Public key window and paste it on the document, after deleting everything that was there before.
 
 It should look like: `ssh-rsa AAAA............== rsa-key-xxxxxxx`
 
-
 ### Adding Your Key to the Packet Portal
-
 
 Once you have generated an SSH key pair you can upload the public key to your account. Via the packet portal, go to "SSH Keys" on the left-hand side and click "Add SSH Key" In the lower right-hand corner.
 
@@ -117,16 +115,12 @@ SSH access on Mac and Linux is straightforward. Simply run the command:
 
 `ssh root@<your_Public IPv4>`
 
-
 Windows
 Run the PuTTY.exe binary downloaded earlier go to "Data" under "Connection", and add root in the field of the username.
 
-
 Go to Authentication, under SSH, and click the Browse button, to add the private SSH key created earlier.
 
-
 ![PuTTy login 1](/images/ssh-access/PuTTY-SSH-Login-1.png)
-
 
 Now go to Session, enter the public IP address of your server, give a name to the session, and click Open.
 


### PR DESCRIPTION
Performed an initial proof read of the articles in the product/ directory.
Cleaned up typos, markdown syntax, and image links where necessary.