### PR TITLE
Initial drone lint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ pipeline:
     build:
         image: alpine
         commands:
-          - apk --no-cache add npm jq curl
-          - npm config set unsafe-perm true // to make the next line run properly, which is caused by node version, apparently
-          - npm install -g markdownlint-cli
-          - markdownlint README.md
+            - apk --no-cache add npm jq curl
+            - npm config set unsafe-perm true
+            - npm install -g markdownlint-cli
+            - markdownlint README.md

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,4 @@
+---
 pipeline:
     build:
         image: alpine


### PR DESCRIPTION
```
yamllint .drone.yml 
.drone.yml
  1:1       warning  missing document start "---"  (document-start)
  5:11      error    wrong indentation: expected 12 but found 10  (indentation)
  6:81      error    line too long (126 > 80 characters)  (line-length)
```