### PR TITLE
Updating build badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![GitHub Forks](https://img.shields.io/github/forks/packethost/docs?color=success)
 ![GitHub Contributors](https://img.shields.io/github/contributors/packethost/docs?color=success)
 ![GitHub License](https://img.shields.io/github/license/packethost/docs?color=success)
-[![Build Status](https://drone.packet.net/api/badges/packethost/docs/status.svg)](https://drone.packet.net/packethost/docs)
+[![Build Status](https://drone.packet.net/api/badges/packethost/docs/status.svg)](https://cloud.drone.io/packethost/docs)
 
 <!--- Headline Description --->
 This is the public documentation for Packet's public services.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![GitHub Forks](https://img.shields.io/github/forks/packethost/docs?color=success)
 ![GitHub Contributors](https://img.shields.io/github/contributors/packethost/docs?color=success)
 ![GitHub License](https://img.shields.io/github/license/packethost/docs?color=success)
-[![Build Status](https://drone.packet.net/api/badges/packethost/docs/status.svg)](https://cloud.drone.io/packethost/docs)
+[![Build Status](https://img.shields.io/drone/build/packethost/docs)](https://cloud.drone.io/packethost/docs)
 
 <!--- Headline Description --->
 This is the public documentation for Packet's public services.


### PR DESCRIPTION
fixing the old links for build badge pointing to drone hosted by packet to cloud.drone.io