### PR TITLE
added markdown-image-cli to drone build file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,4 +59,5 @@ steps:
     commands:
       - npm i -g markdown-image-cli
       - markdown-image-cli -d ./products
+      - markdown-image-cli -d ./guides
     depends_on: [clone]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: docker
-name: Linters
+name: Markdown Structure Linters
 
 trigger:
   repo:
@@ -38,4 +38,25 @@ steps:
     commands:
       - pip3 install --quiet yamllint
       - yamllint  --config-file .yamllint.config --strict .*.yml
+    depends_on: [clone]
+
+---
+kind: pipeline
+type: docker
+name: Markdown Image Linters
+
+trigger:
+  repo:
+    - packethost/docs
+  event:
+    - push
+    - pull-request
+
+
+steps:
+  - name: markdown-image-cli
+    image: node:current-alpine
+    commands:
+      - npm i -g markdown-image-cli
+      - markdown-image-cli -d ./products
     depends_on: [clone]


### PR DESCRIPTION
Developed an initial version of  [markdown-image-cli](https://www.npmjs.com/package/markdown-image-cli) specifically designed for this project.

It is now covering /products and /guides