### PR TITLE
removed /guides from markdown-image-cli

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,5 +59,4 @@ steps:
     commands:
       - npm i -g markdown-image-cli
       - markdown-image-cli -d ./products
-      - markdown-image-cli -d ./guides
     depends_on: [clone]


### PR DESCRIPTION
temporarily removing /guides from markdown-image-cli to fix the document causing the issue