### PR TITLE
Add content to custom-images.md and fix text in cpr.md

### DIFF
--- a/products/03-servers/03-key-features/09-cpr.md
+++ b/products/03-servers/03-key-features/09-cpr.md
@@ -1,0 +1,419 @@
+<!--<meta>
+{
+    "title":"Custom Partitioning and RAID",
+    "description":"Setting up CPR (Custom Partitioning & RAID).",
+    "tag":["CPR", "Custom RAID", "RAID", "Partition", "Disk Configuration", "SATA", "HDD", "SSD", "NVMe"]
+}
+</meta>-->
+
+# Custom Partitioning & Raid (CPR)
+
+Custom Partitioning & Raid (CPR) is a powerful and yet easy to use feature that helps you configure the disk configuration of Reserved Hardware instances during deployment.  
+
+_Please note: this feature is not available for on-demand instances.  A reserved device is required.  This is because with reserved devices, our system knows the exact drive scheme to allow such customization.  However, all of our machine types can be converted to reserved hardware, so just reach out to [support@packet.com](mailto:support@packet.com) to arrange a reservation._
+
+## Getting Started
+
+First things first, you should be familiar with the [API calls available for device provisioning](https://www.packet.com/developers/api/devices/), you'll need them! You can find examples for deploying reserved hardware [here](/products/01-getting-started/03-deployment-options/03-reserved-hardware.md).
+
+You should also be aware of our standard disk configurations for each server type.  With a few hardware-specific exceptions, generally speaking, this looks like:
+
+*   __t1.small.x86__:   1 × 80 GB SSD (Boot)
+*   __c1.small.x86__:   2 × 120 GB SSD in RAID 1 (Boot)
+*   __c1.large.arm__: 1 × 340 GB SSD (Boot)
+*   __c2.large.arm__: 1 × 480 GB SSD (Boot)
+*   __c1.xlarge.x86__:  2 × 120 GB SSD in RAID 1 (Boot) & 1.6 TB of NVMe Flash
+*   __c2.medium.x86__: 960 GB of SSD (2 x 480 GB) (1 for Boot)
+*   __c3.medium.x86__: 960 GB of SSD (2 x 480 GB) (1 for Boot)
+*   __m1.xlarge.x86__:   6 × 480GB SSD (1 for Boot)
+*   __m2.xlarge.x86__: 2 × 120 GB SSD (1 for Boot) & 3.8 TB of NVMe Flash
+*   __x1.small.x86__:   1 × 240 GB SSD (Boot)
+*   __x2.xlarge.x86__: 1 × 120 GB SSD (Boot) , 2 × 240 GB SSD & 3.8 TB of NVMe Flash
+*   __n2.xlarge.x86__: 2 × 240 GB SSD in Hardware RAID 1 (Boot) & 3.8 TB of NVMe Flash
+*   __g2.large.x86__: 1 x 150 GB SSD (Boot), 2 x 480 GB SSD
+*   __s1.large.x86__:  1 x 120 GB SSD (Boot), 2 x 480 GB SSD & 12 X 2 TB HDD.
+
+_Some servers are UEFI only and require an extra step for the CPR configuration. Please check the [last section](#efi-partition-requirement-for-uefi-only-servers) of this article for the details of UEFI only servers._
+
+## Using CPR During Provisioning
+
+Let's say you are going to deploy one of your reserved instances. An example [call to the API](https://www.packet.com/developers/api/devices/) might look like this:
+
+```
+curl -X POST -H "X-Auth-Token: token" -H "Content-Type: application/json" -d '
+{
+  "hardware_reservation_id": "string",
+  "hostname": "string",
+  "billing_cycle": "string",
+  "operating_system": "string",
+  "storage": {JSON Object},
+  "userdata": "string",
+  "tags": ["string"]
+}' "https://api.packet.net/projects/{ID}/devices"
+```
+Note: 'storage' and 'JSON Object' are where you would specifically state your storage configuration requirements.
+
+## Drive Type Name Differences (SATA HDDs, SATA SSDs, and NVMe Flash)
+It's worth noting that the OS will use a different naming scheme for NVMe drives compared to standard SSDs and HDDs which are usually seen in the format of `sda`, `sdb` etc. On the other hand, NVMe drives usually follow the naming scheme of `nvme0n1`, `nvme1n1` etc. To get accurate drive names, we suggest that you deploy the server and go into rescue mode (Alpine OS). Then run `fdisk -l` to list all drives.
+
+When partitioning, standard drives are usually followed by a number, so `sda1` and `sda2` while NVMe drives are usually followed by a `p` and number, so it would be `nvme0n1p1` and `nvme0n1p2`.
+
+## t1.small.x86 CPR Example
+
+Using a simple t1.small.x86 to start, the following example shows you how to:
+
+* State which disks you want to format.
+* How you want these disks formatted.
+* What filesystem should be created.
+* Where to mount the partition once created.
+
+```
+{
+  "disks": [
+    {
+      "device": "/dev/sda",
+      "wipeTable": true,
+      "partitions": [
+        {
+          "label": "BIOS",
+          "number": 1,
+          "size": 4096
+        },
+        {
+          "label": "SWAP",
+          "number": 2,
+          "size": "3993600"
+        },
+        {
+          "label": "ROOT",
+          "number": 3,
+          "size": 0
+        }
+      ]
+    }
+  ],
+  "filesystems": [
+    {
+      "mount": {
+        "device": "/dev/sda3",
+        "format": "ext4",
+        "point": "/",
+        "create": {
+          "options": [
+            "-L",
+            "ROOT"
+          ]
+        }
+      }
+    },
+    {
+      "mount": {
+        "device": "/dev/sda2",
+        "format": "swap",
+        "point": "none",
+        "create": {
+          "options": [
+            "-L",
+            "SWAP"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+## m1.xlarge.x86 example
+The next exmaple is a slightly more complicated configuration that includes RAID. It's worth noting that RAID created through CPR is software RAID, not hardware RAID.
+```
+{
+   "disks":[
+      {
+         "device":"/dev/sda",
+         "wipeTable":true,
+         "partitions":[
+            {
+               "label":"BIOS",
+               "number":1,
+               "size":4096
+            },
+            {
+               "label":"SWAPA1",
+               "number":2,
+               "size":"3993600"
+            },
+            {
+               "label":"ROOTA1",
+               "number":3,
+               "size":0
+            }
+         ]
+      },
+      {
+         "device":"/dev/sdb",
+         "wipeTable":true,
+         "partitions":[
+            {
+               "label":"BIOS",
+               "number":1,
+               "size":4096
+            },
+            {
+               "label":"SWAPA2",
+               "number":2,
+               "size":"3993600"
+            },
+            {
+               "label":"ROOTA2",
+               "number":3,
+               "size":0
+            }
+         ]
+      }
+   ],
+   "raid":[
+      {
+         "devices":[
+            "/dev/sda2",
+            "/dev/sdb2"
+         ],
+         "level":"1",
+         "name":"/dev/md/SWAP"
+      },
+      {
+         "devices":[
+            "/dev/sda3",
+            "/dev/sdb3"
+         ],
+         "level":"1",
+         "name":"/dev/md/ROOT"
+      }
+   ],
+   "filesystems":[
+      {
+         "mount":{
+            "device":"/dev/md/ROOT",
+            "format":"ext4",
+            "point":"/",
+            "create":{
+               "options":[
+                  "-L",
+                  "ROOT"
+               ]
+            }
+         }
+      },
+      {
+         "mount":{
+            "device":"/dev/md/SWAP",
+            "format":"swap",
+            "point":"none",
+            "create":{
+               "options":[
+                  "-L",
+                  "SWAP"
+               ]
+            }
+         }
+      }
+   ]
+}
+```
+
+## m2.xlarge.x86 with RAID and NVMe drive example
+
+This example is more complex than the others as it involves different RAID setups for the ROOT and SWAP partitions as well as mounting the NVMe drive during deployment.
+
+```
+{
+        "disks": [
+            {
+                "device": "/dev/sda",
+                "wipeTable": true,
+                "partitions": [
+                    {
+                        "label": "BIOS",
+                        "number": 1,
+                        "size": 4096
+                    },
+                    {
+                        "label": "SWAP",
+                        "number": 2,
+                        "size": "8G"
+                    },
+                    {
+                        "label": "ROOT",
+                        "number": 3,
+                        "size": 0
+                    }
+                ]
+            },
+            {
+                "device": "/dev/sdb",
+                "wipeTable": true,
+                "partitions": [
+                    {
+                        "label": "BIOS",
+                        "number": 1,
+                        "size": 4096
+                    },
+                    {
+                        "label": "SWAP",
+                        "number": 2,
+                        "size": "8G"
+                    },
+                    {
+                        "label": "ROOT",
+                        "number": 3,
+                        "size": 0
+                    }
+                ]
+            },
+            {
+                "device": "/dev/nvme0n1",
+                "wipeTable": true,
+                "partitions": [
+                    {
+                        "label": "VAR1",
+                        "number": 1,
+                        "size": 0
+                    }
+                ]
+            }            
+        ],
+        "raid": [
+            {
+                "devices": [
+                    "/dev/sda3",
+                    "/dev/sdb3"
+                ],
+                "level": "0",
+                "name": "/dev/md/ROOT"
+            },
+            {
+                "devices":[
+                   "/dev/sda2",
+                   "/dev/sdb2"
+                ],
+                "level":"1",
+                "name":"/dev/md/SWAP"
+             }
+        ],
+        "filesystems": [
+            {
+                "mount": {
+                    "device": "/dev/md/ROOT",
+                    "format": "ext4",
+                    "point": "/",
+                    "create": {
+                        "options": [
+                            "-L",
+                            "ROOT"
+                        ]
+                    }
+                }
+            },
+            {
+                "mount": {
+                    "device": "/dev/nvme0n1p1",
+                    "format": "ext4",
+                    "point": "/var",
+                    "create": {
+                        "options": [
+                            "-L",
+                            "VAR1"
+                        ]
+                    }
+                }
+            },
+            {
+                "mount":{
+                   "device":"/dev/md/SWAP",
+                   "format":"swap",
+                   "point":"none",
+                   "create":{
+                      "options":[
+                         "-L",
+                         "SWAP"
+                      ]
+                   }
+                }
+            }
+        ]
+    }
+```
+
+
+## EFI Partition Requirement for UEFI only servers
+
+For the c1.large.arm, c2.large.arm, c2.medium.x86, and c3.medium.x86 servers which are UEFI only, you are required to use a FAT32 EFI partition for `/boot/efi` - The default c2.medium.x86 CPR configuration looks like the following:
+
+```
+{
+		"disks": [
+			{
+				"device": "/dev/sda",
+				"wipeTable": true,
+				"partitions": [
+					{
+						"label": "BIOS",
+						"number": 1,
+						"size": "512M"
+					},
+					{
+						"label": "SWAP",
+						"number": 2,
+						"size": "3993600"
+					},
+					{
+						"label": "ROOT",
+						"number": 3,
+						"size": 0
+					}
+				]
+			}
+		],
+		"filesystems": [
+			{
+				"mount": {
+					"device": "/dev/sda1",
+					"format": "vfat",
+					"point": "/boot/efi",
+					"create": {
+						"options": [
+							"32",
+							"-n",
+							"EFI"
+						]
+					}
+				}
+			},
+			{
+				"mount": {
+					"device": "/dev/sda3",
+					"format": "ext4",
+					"point": "/",
+					"create": {
+						"options": [
+							"-L",
+							"ROOT"
+						]
+					}
+				}
+			},
+			{
+				"mount": {
+					"device": "/dev/sda2",
+					"format": "swap",
+					"point": "none",
+					"create": {
+						"options": [
+							"-L",
+							"SWAP"
+						]
+					}
+				}
+			}
+		]
+	}
+```

--- a/products/03-servers/03-operating-systems/03-custom-images.md
+++ b/products/03-servers/03-operating-systems/03-custom-images.md
@@ -6,10 +6,107 @@
 }
 </meta>-->
 
-Packet leverages GitHub to transparently manage our officially supported Operating System images.  You can view the repos for each official image here.
+Official Images
+Packet leverages GitHub to transparently manage our officially supported Operating System images. You can view the repos for each official image at https://github.com/packethost/packet-images.
 
 In addition to providing a public change log, this process enables users to programmatically "pin" their installs to particular OS versions, improving the stability (dare we say immutability!) of your deployments.
 
+Why Use a Custom Image?
 Packet's official images are optimized for speed and therefore only have the minimum number of packages installed.
 
 There are different use cases where the ability to deploy a custom image can reduce deployment time and streamline your workflow, especially in very active environments. While you can always install and remove packages (or adjust your kernel) after deploying an official Packet OS image, using a custom image can "front-load" these customization.  
+
+Building a Custom Image
+In this example, we will build a custom Ubuntu 16.04 image for use on a c1.small server.
+
+Prerequisites: This assumes you have an active GitHub/Lab account. Also, the following packages are required to proceed.
+
+* git-lfs  
+```
+apt get install git-lfs
+```
+* get-ubuntu-image  
+```
+wget https://raw.githubusercontent.com/packethost/packet-images/master/tools/get-ubuntu-image
+```
+* make get-ubuntu-image executable  
+```
+chmod +x /path/to/file
+```
+* packet-save2image  
+```
+wget https://raw.githubusercontent.com/packethost/packet-images/master/tools/packet-save2image
+```
+* set packet-save2image to executable  
+```
+chmod +x /<path>/packet-save2image
+```
+* initrd.tar.gz  
+```
+wget https://github.com/packethost/packet-images/raw/ubuntu_16_04-c1.small.x86/initrd.tar.gz
+```
+* kernel.tar.gz  
+```
+wget https://github.com/packethost/packet-images/raw/ubuntu_16_04-c1.small.x86/kernel.tar.gz
+```
+* modules.tar.gz  
+```
+wget https://github.com/packethost/packet-images/raw/ubuntu_16_04-c1.small.x86/modules.tar.gz
+```
+* DockerFile  
+```
+wget https://raw.githubusercontent.com/packethost/packet-images/ubuntu_16_04-base/x86_64/Dockerfile
+```
+
+With the prerequisites out of the way, it's time to begin building the custom image.
+
+In the Dockerfile, you are welcome to add/remove packages as you see fit. In this example though, we've added an additional RUN command, to prove that our example worked!
+```
+RUN echo "hello world" > /root/helloworld
+```
+
+Download Image:
+```
+./get-ubuntu-image 16.04 x86_64 .
+```
+Build:
+```
+docker build -t custom-ubuntu-16 .
+```
+Save:
+```
+docker save custom-ubuntu-16 > custom-ubuntu-16.tar
+```
+Package:
+```
+./packet-save2image < custom-ubuntu-16.tar > image.tar.gz
+```
+**️Please Note:** custom-ubuntu-16 is the example name, please name your image as you see fit.
+
+Cleanup:
+Once you have saved the image with packet-save2image  you can do some clean up in the specific directory where the custom image files reside, the following is an example:
+```
+rm SHA256SUMS*
+rm ubuntu-base-16.04.4-base-amd64.tar.gz
+rm rootfs.tar.gz rm custom-ubuntu-16.tar
+rm get-ubuntu-image packet-save2image
+```
+Track, add, commit, and push your custom image to your repo
+```
+git lfs track *.tar.gz
+git add Dockerfile .gitattributes image.tar.gz initrd.tar.gz  kernel.tar.gz  modules.tar.gz
+git commit -m "Custom Ubuntu Image"
+git push origin {your-repo}
+```
+
+Deploying Your Custom Image
+Now that you've created your custom image, you can deploy it by specifying the repo and image tag via UserData at the time of deployment:
+```
+#cloud-config
+#image_repo=https://somegitserver/user/image-repo.git #image_tag=b1ce89c2584b9fe1513ec72a481fd1c662db6808
+```
+️The image_repo will be the clone address of the giithub/lab repo where you pushed the image, and the image_tag is the hash of the last commit on that repo.
+
+In the portal you'll add the UserData using the "options" slide out.
+![deploy server](/images/custom-images/Deploy-Custom-Image-1.png)
+![add userdata](/images/custom-images/Deploy-Custom-Image-2.png)


### PR DESCRIPTION
The custom  images document was missing a lot of information.
This commit restores it to a usable state.

The cpr guide had some leftover markings from a merge conflict resolution.
This commit removes these markings.