### PR TITLE
Revise user-state doc

### DIFF
--- a/guides/layer-2-configurations.md
+++ b/guides/layer-2-configurations.md
@@ -39,7 +39,7 @@ The following are different scenarios that we will be covering in this guide:
 * Hybrid and pure L2: A cluster of private hosts in layer 2 mode and using a single node in hybrid mode as an internet gateway.  
 
 
-**Please Note:** For the purpose of this guide, we are using eth0/eth1 to represent the first and second interfaces. The actual interface name will depend on what operating system and server configuration you are using.**
+**Please Note:** For the purpose of this guide, we are using eth0/eth1 to represent the first and second interfaces. The actual interface name will depend on what operating system and server configuration you are using.
 
 ## Configuration #1: Leaving eth0 in bond0 and adding a single VLAN to eth1.
 

--- a/products/03-servers/02-key-features/12-user-state.md
+++ b/products/03-servers/02-key-features/12-user-state.md
@@ -37,7 +37,7 @@ Returns:
 http://tinkerbell.ewr1.packet.net/events
 ```
 
-* Post a Custom User State: If you want to send a custom user state, you should send a POST request to the user state endpoint you retrieved earlier. This will add an event to the device's timeline and also display a message in the portal timeline section.  
+* Post a Custom User State: If you want to send a custom user state event, you should send a POST request to the user state endpoint you retrieved earlier. This will add an event to the device's timeline and also display a message in the portal timeline section.  
 ```
 curl -X POST -d '{"state":"running","code":1007,"message":"Im still provisioning!!!"}' http://tinkerbell.ewr1.packet.net/events
 ```

--- a/products/03-servers/02-key-features/12-user-state.md
+++ b/products/03-servers/02-key-features/12-user-state.md
@@ -28,8 +28,12 @@ With our User State feature, you can see when the user-data install actually beg
 We support passing a specific user state to our API, but this has to happen from within the device itself.    
 
 * Get the User State Url: First, from a device, get the User State Url by querying our metadata service for the user_state_url. This will slightly differ based on facility location, for this example the server is located in EWR1.  (hint: you might want to install and use jq in order to help automate this).  
+
 ```
 curl https://metadata.packet.net/metadata | jq -r .user_state_url
+```
+Returns:
+```
 http://tinkerbell.ewr1.packet.net/events
 ```
 

--- a/products/03-servers/02-key-features/12-user-state.md
+++ b/products/03-servers/02-key-features/12-user-state.md
@@ -58,7 +58,7 @@ The POST request can accept the following data options:
 
 ### Useful script
 
-The following is a BASH script that you can use to easily send user-state events.
+The following is a BASH script that you can use to easily send user-state events either in your custom-image installation process or user-data stages.
 
 ```
 #!/bin/bash

--- a/products/03-servers/02-key-features/12-user-state.md
+++ b/products/03-servers/02-key-features/12-user-state.md
@@ -54,3 +54,27 @@ The POST request can accept the following data options:
 * state (running, succeeded, or failed)
 * code (anything between 1000 and 1099, inclusive)
 * message (can be anything you want!)
+
+
+### Useful script
+
+The following is a BASH script that you can use to easily send user-state events.
+
+```
+#!/bin/bash
+url="$(curl https://metadata.packet.net/metadata | jq -r .user_state_url)"
+
+send_user_state_event() {
+          data=$(
+          echo "{}" \
+              | jq '.state = $state | .code = ($code | tonumber) | .message = $message' \
+               --arg state "$1" \
+               --arg code "$2" \
+               --arg message "$3"
+          )
+          echo curl -v -X POST -d "$data" "$url"
+}
+
+send_user_state_event running 1000 "hey im still running"
+send_user_state_event succeeded 1001 "hey im done now :)"
+```

--- a/products/03-servers/02-key-features/12-user-state.md
+++ b/products/03-servers/02-key-features/12-user-state.md
@@ -37,7 +37,7 @@ Returns:
 http://tinkerbell.ewr1.packet.net/events
 ```
 
-* Post a Custom User State: If you want to send a custom user state, you should send a POST request to the user state endpoint you retrieved earlier. . This will add an event to the device's timeline and also display a message in the portal timeline section.  
+* Post a Custom User State: If you want to send a custom user state, you should send a POST request to the user state endpoint you retrieved earlier. This will add an event to the device's timeline and also display a message in the portal timeline section.  
 ```
 curl -X POST -d '{"state":"running","code":1007,"message":"Im still provisioning!!!"}' http://tinkerbell.ewr1.packet.net/events
 ```

--- a/products/03-servers/02-key-features/12-user-state.md
+++ b/products/03-servers/02-key-features/12-user-state.md
@@ -3,7 +3,7 @@
 {
     "title":"User State",
     "description":"Leverage 'user state' options to inform the Packet API about custom provisioning events.",
-    "tag":["user", "state"]
+    "tag":["user", "state", "timeline", "events"]
 }
 </meta>
 -->
@@ -27,22 +27,21 @@ With our User State feature, you can see when the user-data install actually beg
 ### How to Create a Custom User State
 We support passing a specific user state to our API, but this has to happen from within the device itself.    
 
-* Get the Phone Home IP: First, from a device, get the phone-home IP address by querying our metadata service for the phone_home_url.  (hint: you might want to install and use jq in order to help automate this).  
+* Get the User State Url: First, from a device, get the User State Url by querying our metadata service for the user_state_url. This will slightly differ based on facility location, for this example the server is located in EWR1.  (hint: you might want to install and use jq in order to help automate this).  
 ```
-curl https://metadata.packet.net/metadata | jq -r .phone_home_url
-http://147.75.195.231/phone-home
+curl https://metadata.packet.net/metadata | jq -r .user_state_url
+http://tinkerbell.ewr1.packet.net/events
 ```
 
-* Post a Custom User State: If you want to send a custom user state, you should POST a request to that IP on the /events URL. This will add an event to the device's timeline and also display a message in the portal.  
+* Post a Custom User State: If you want to send a custom user state, you should send a POST request to the user state endpoint you retrieved earlier. . This will add an event to the device's timeline and also display a message in the portal timeline section.  
 ```
-curl -X POST -d '{"state":"running","code":1007,"message":"Whoops"}'
-http://147.75.195.231/events
+curl -X POST -d '{"state":"running","code":1007,"message":"Im still provisioning!!!"}' http://tinkerbell.ewr1.packet.net/events
 ```
 This allows you to see the custom user state event on the device timeline and device detail page:
 
 * Indicate Success: You'll want to finish things off by communicating a successful install, changing the state to succeeded and maybe adding a cool message there.  
 ```
-curl -X POST -d '{"state":"succeeded","code":1099,"message":"I am ready now!!!"}' http://147.75.195.231/events
+curl -X POST -d '{"state":"succeeded","code":1099,"message" : "Im ready now!!!"}' http://tinkerbell.ewr1.packet.net/events
 ```
 
 ### Available Options

--- a/products/03-servers/02-key-features/12-user-state.md
+++ b/products/03-servers/02-key-features/12-user-state.md
@@ -17,7 +17,7 @@ Usually when our system reports that a server is "Active" it means that a provis
 
 When the provisioning system detects any of these two custom installation types, it will set the provision as "Active" very early in the process - basically once we are done with our part and begin installing the provided image.  
 
-However, this "Active" state can be a bit misleading, as there is usually work still ongoing (such as installing your custom image!). This is where you can leverage a custom "user state" option to gain better control over the process.
+However, this "Active" state can be a bit misleading, as there is usually work still ongoing (such as installing your custom image!). This is where you can leverage a custom "user state" option to gain better control over the process. Custom user state events are also useful if you're running long user-data scripts/configurations and prefer to have better visibility into the process.
 
 ### Custom User State for Managing User Data
 Another way to use this feature is when you leverage a lot of user-data during a normal installation. This can get bulky, and long running user-data leaves you a bit in the dark as to the state of your provision.


### PR DESCRIPTION
Slightly changed the doc as part of the new user_state_url addition to the metadata endpoint which makes the process easier. Also added a useful script that makes it easier to send user-state events.

Fixed a small issue in the layer 2 configurations guide.