### PR TITLE
Layer2 networking product doc improvements

### DIFF
--- a/products/network/advanced/layer-2.md
+++ b/products/network/advanced/layer-2.md
@@ -44,9 +44,10 @@ gateway, for example.
 
 Layer 2 - Bonded mode converts the bonded network interface to pure Layer 2
 mode. This means all access to the public internet is lost, and the host can
-only be reached by the Serial Over SSH (SOS) console. In this configuration the
-network bond is intact, so only one network interface will be available for
-attaching VLANs.
+only be reached by the [Serial Over SSH (SOS)
+console](https://www.packet.com/developers/docs/servers/key-features/sos-serial-over-ssh/).
+In this configuration the network bond is intact, so only one network interface
+will be available for attaching VLANs.
 
 Layer 2 - Individual mode (also known as a "broken bond mode") is similar to the
 Layer 2 - Bonded mode configuration, except the network bond is also dismantled,

--- a/products/network/advanced/layer-2.md
+++ b/products/network/advanced/layer-2.md
@@ -11,61 +11,109 @@
 }
 </meta> -->
 
+Packet servers are configured with a Layer 3 network configuration by default.
 
-Our network is designed around a pure Layer 3 network topology, where we bring a routed interface to each server.  However, many environments expect a Layer 2 network. To support these use cases we’ve developed a feature that allows users to create and connect Layer 2 networks to their Packet infrastructure.
+Many bare metal environments benefit from Layer 2 networking to manage services
+like DHCP and routing within a private network. To support these use cases we’ve
+developed a feature that allows users to add Layer 2 virtual networks to their
+Packet infrastructure.
 
-A few notes to help set the stage:
-
-* Availability in all datacenters.
-* Available on all server types except our t1.small.x86 and c1.small.x86. The x1.small.x86 supports hybrid mode only.
-* Virtual networks are confined to a single datacenter.
-* There are no fees for the use of the Layer 2 feature.
-
+You can attach servers in the same project within the same data center to
+numerous Layer 2 virtual networks. This feature is available in all data centers
+for no added fee.
 
 ### Network configuration types
 
-When converting from layer 3 to another network type there are 3 possible configurations to choose from: hybrid mode, bonded layer two, or layer 2 with a broken network bond.
+The server Network page in the Portal offers a configuration panel that makes it
+easy to change types.  The network type can also be managed from the
+[`device_network_type` resource in the Packet Terraform
+provider](https://registry.terraform.io/providers/packethost/packet/latest/docs/resources/device_network_type).
 
-In hybrid mode only one network interface is removed from bond and placed in layer two mode. VLANs can then be attached to this interface for Layer 2 connectivity. This preserves layer 3 connectivity to the server via bond0, so it can be accessed via the public IP.
+When converting from Layer 3 to another network type there are 3 possible
+configurations to choose from:
 
-Bonded Layer 2 converts the bonded network interface to pure Layer 2 mode. This means all access to the public internet is lost, and the host can only be reached by the Serial Over SSH (SOS) console. In this configuration the network bond is intact, so only one network interface will be available for attaching VLANs.
+* Hybrid mode
+* Layer 2 - Bonded mode
+* Layer 2 - Individual mode
 
-Layer two with a broken bond is similar to the bonded Layer 2 configuration, except the network bond is also dismantled, thus, providing two network interfaces available for VLANs.
+In Hybrid mode, only one network interface is removed from bond and placed in
+Layer 2 mode. VLANs can then be attached to this interface for Layer 2
+connectivity. This preserves Layer 3 connectivity to the server via bond0, so it
+can be accessed via the public IP.  This mode can be used to provide a NAT
+gateway, for example.
 
-Note: both pure Layer 2 networking configurations will permanently remove the server's IP management IP addresses. If the server is later converted back to Layer 3, new IP addresses will be assigned.
+Layer 2 - Bonded mode converts the bonded network interface to pure Layer 2
+mode. This means all access to the public internet is lost, and the host can
+only be reached by the Serial Over SSH (SOS) console. In this configuration the
+network bond is intact, so only one network interface will be available for
+attaching VLANs.
 
+Layer 2 - Individual mode (also known as a "broken bond mode") is similar to the
+Layer 2 - Bonded mode configuration, except the network bond is also dismantled,
+thus, providing two network interfaces available for VLANs.
+
+Please note that converting a server to either Layer 2 networking configuration
+will permanently remove the server's management IP addresses. When the server is
+converted back to Layer 3, new IP addresses will be assigned.
+
+#### Server types
+
+Layer 2 networking features are not available or are limited on some server
+types.
+
+* t1.small.x86 and c1.small.x86 servers support Layer 3 only.
+* x1.small.x86 servers support Hybrid (Layer 2 + Layer 3) mode only.
 
 ## Reverting to Layer 3 from Layer 2
 
-Reverting to Layer 3 from Layer 2 via the portal only require changing the networking mode via the server's networking page. Our API will automatically bond the network interfaces and assign a new IP address.
+The server networking page in the Portal allows you to revert back to the
+default Layer 3 configuration from a Layer 2 configuration.
+
+When changing the network type in this way, the Portal automates the bonding of
+network interfaces and assigns new IP addresses.
 
 ## Functional Description
 
+On the server configuration screen in the Portal, the switch ports serving each
+of your server's NICs may be independently enabled to switch one or more of your
+provisioned networks.
 
-In the portal server configuration screen, the switch ports serving each of your servers' NICs may be independently enabled to switch one or more of your provisioned networks.
-
-If only one VLAN is enabled on a port, packets are untagged. This means that the server's network configuration does not need to be VLAN-aware. However when two or more VLANs are enabled on a port, then packets are tagged and therefore it will be necessary to configure the server's networking accordingly.
+If only one VLAN is enabled on a port, packets are untagged. This means that the
+server's network configuration does not need to be VLAN-aware. However when two
+or more VLANs are enabled on a port, then packets are tagged and therefore it
+will be necessary to configure the server's networking accordingly.
 
 ## Layer 2 Setup in the Packet Portal
 
-Layer 2 networking is enabled in the Packet Portal from the project's "IPs and Networks" tab.
+Layer 2 networking is enabled in the Packet Portal from the project's "IPs and
+Networks" tab.
 
 Under "Layer 2" you can add one or more networks like this:
 
-![add VLAN](/images/layer-2-overview/add-vlan.jpg)
+![add VLAN](../../../images/layer-2-overview/add-vlan.jpg)
 
-Note that networks are local to a specific data center and that the assigned VLAN ID displayed here will be used to configure server port switching and server network setup.
+Note that networks are local to a specific data center and that the assigned
+VLAN ID displayed here will be used to configure server port switching and
+server network setup.
 
-When you add a network, we automatically provision it in our data center switches; however, in order for it to be made available to individual machines additional steps are required.
+When you add a network, we automatically provision it in our data center
+switches; however, in order for it to be made available to individual machines
+additional steps are required.
 
-1. Convert the server's networking mode. This will configure the server to allow attachment of your server's network interfaces to your VLAN. You can choose a mix/hybrid pure Layer 2 (with the option to break the bond or leave it intact).
+1. Convert the server's networking mode. This will configure the server to allow
+   attachment of your server's network interfaces to your VLAN. You can choose a
+   mix/hybrid pure Layer 2 (with the option to break the bond or leave it
+   intact).
 
-![convert network](/images/layer-2-overview/convert-network-mode.jpg)
+   ![convert network](../../../images/layer-2-overview/convert-network-mode.jpg)
 
-2. Once the network mode has been changed you will see the option to attach a new VLAN.
+1. Once the network mode has been changed you will see the option to attach a
+   new VLAN.
 
-![attach VLAN](/images/layer-2-overview/attach-vlan-step1.jpg)
+   ![attach VLAN](../../../images/layer-2-overview/attach-vlan-step1.jpg)
 
-3. Choose the network interface you wish to attach the VLAN to, but be aware that you should only choose "bond0" if you have converted the server to the bonded layer 2 networking mode.
+1. Choose the network interface you wish to attach the VLAN to, but be aware
+   that you should only choose "bond0" if you have converted the server to the
+   bonded layer 2 networking mode.
 
-![VLAN menue](/images/layer-2-overview/attach-vlan-step2.jpg)
+   ![VLAN menue](../../../images/layer-2-overview/attach-vlan-step2.jpg)

--- a/products/network/getting-started.md
+++ b/products/network/getting-started.md
@@ -11,28 +11,46 @@
 }
 </meta> -->
 
+Packet’s network and data center topology is designed with performance and
+redundancy as top priorities. Two unique features include a Layer-3 topology and
+native dual-stack (IPv4 / IPv6) capability.
 
+With our Layer-3 network design, each server is directly attached to a physical
+switch with 2 x 1Gbps copper, 2 x 10Gbps SFP+, or 4 x 10Gbps SFP+ connections.
+This provides elastic, cloud-style networking without the slow, latency-inducing
+characteristics often associated with complex overlays. For use cases that
+require Layer 2 functionality, please check out our [Layer 2
+feature](https://www.packet.com/developers/docs/network/advanced/layer-2).
 
-Packet’s network and datacenter topology is designed with performance and redundancy as top priorities. Two unique features include a Layer-3 topology and native dual-stack (IPv4 / IPv6) capability.
+For redundancy, each server has dedicated dual network connections going into
+two Top-of-Rack (ToR) switches. These physical connections are virtually bonded
+together as follows:
 
-With our Layer-3 network design, each server is directly attached to a physical switch via either 2 x 1Gbps copper or 2 x 10Gbps SFP+ connections. This provides elastic, cloud-style networking without the slow, latency-inducing characteristics often associated with complex overlays. For use cases that require Layer 2 functionality, please check out our [Layer 2 feature](https://www.packet.com/developers/docs/network/advanced/layer-2).
+| Server   | Throughput | Port Configuration
+| -------- | --------   | -------------
+| n2.large | 20 Gbps    | 4 × 10 Gbps (802.3ad/LACP), Quad-port Intel x710
+| c3.small | 20 Gbps    | 2 x 10 Gbps (802.3ad/LACP)
+| c3.medium| 20 Gbps    | 2 x 10 Gbps (802.3ad/LACP)
+| m3.large | 20 Gbps    | 2 x 10 Gbps (802.3ad/LACP)
+| s3.large | 20 Gbps    | 2 x 10 Gbps (802.3ad/LACP)
+| g2.large | 20 Gbps    | 2 × 10 Gbps (802.3ad/LACP)
+| m2.xlarge| 20 Gbps    | 2 x 10 Gbps (802.3ad/LACP), Mellanox ConnectX-4 NICs
+| c2.medium| 20 Gbps    | 2 x 10 Gbps (802.3ad/LACP), Mellanox ConnectX NICs
+| s1.large | 20 Gbps    | 2 × 10 Gbps (802.3ad/LACP), Mellanox ConnectX NICs
+| m1.xlarge| 20 Gbps    | 2 × 10 Gbps (802.3ad/LACP), Mellanox ConnectX NICs
+| c1.xlarge| 20 Gbps    | 2 × 10 Gbps (802.3ad/LACP), Mellanox ConnectX NICs
+| c1.small | 2 Gbps     | 2 × 1  Gbps (802.3ad/LACP), Intel NICs
+| x1.small | 10 Gbps    | 2 x 10 Gbps (mode 5/balance-tlb), Intel X710 NICs
+| t1.small | 2.5 Gbps   | 2 × 2.5 Gbps (mode 5/balance-tlb), Intel NICs
 
-For redundancy, each server has dedicated dual network connections going into two Top-of-Rack (ToR) switches. These two physical connections are virtually bonded together as follows:
+___
 
+In **802.3ad** mode, all interfaces send and receive traffic equally.
 
-| Type  | Network |
-| ------------- | ------------- |
-| c3.small|  20 Gbps Bonded Network (2 x 10Gbps Ports w/ LACP)
-| c3.medium| 20 Gbps Bonded Network (2 x 10Gbps Ports w/ LACP)
-| m3.large| 20 Gbps Bonded Network  (2 x 10Gbps Ports w/ LACP)
-| s3.large| 20 Gbps Bonded Network  (2 x 10Gbps Ports w/ LACP)
-| t1.small|  2.5 Gbps Network (2 × Intel NICs 2.5Gbps w/ TLB) full hardware redundancy but no active/active bond.
-| c1.small|  2 Gbps Bonded Network (2 × Intel NICs 1Gbps w/ LACP) full hardware redundancy and active/active bond.
-| x1.small| 10 Gbps Network (2 x Intel X710 NICs 10 Gbps w/ TLB) full hardware redundancy but no active/active bond.
-| m1.xlarge| 20 Gbps Bonded Network (2 × Mellanox ConnectX NICs, 10Gbps w/ LACP) full hardware redundancy and active/active bond.
-|c1.xlarge| 20 Gbps Bonded Network (2 × Mellanox ConnectX NICs, 10Gbps w/ LACP) full hardware redundancy and active/active bond.
-|s1.large|20 Gbps Bonded Network ( 2 × Mellanox ConnectX NICs, 10 Gbps w/ LACP) full hardware redundancy and active/active bond.
-|m2.xlarge| 20Gbps Network Pipe with 2 x 10 Gbps Bonded NICs in an HA configuration (2 x 10Gbps Mellanox Connect-X 4 NICs)
-|c2.medium| 20Gbps Network Pipe with 2 x 10 Gbps Bonded NICs in an HA configuration (2 x Mellanox ConnectX NICs)
-|g2.large| 20Gbps Bonded Network 2 × 10GBPS W/ LACP
-|n2.large| Quad-port Intel x710  (4 × 10GBPS W/ LACP)
+In **mode 5/balance-tlb** mode, all interfaces send outbound traffic, while only
+1 interface, considered the primary NIC, receives inbound traffic at a time. If
+the primary NIC were to go down, incoming traffic will seamlessly flow to the
+other NIC.
+
+See <https://en.wikipedia.org/wiki/Link_aggregation> for more in depth
+information.


### PR DESCRIPTION
Readability improvements and an extra column (and clarity) for the networking / device-model overview table.

@mmlb and @pereztr5 contributed to the wording and review of this.

These changes are easiest reviewed in the rich diff view:

> ![image](https://user-images.githubusercontent.com/317653/91095433-5b1f1500-e62a-11ea-9cbf-383f4e128f6c.png)

The language used here is still a bit clumsy when talking about virtual network, VLAN, and Layer2 network. Perhaps all of these references would be best described as virtual private networks, but that terminology may create confusion with the Doorman VPN.